### PR TITLE
Haiku support in dotnet/arcade

### DIFF
--- a/eng/common/cross/toolchain.cmake
+++ b/eng/common/cross/toolchain.cmake
@@ -7,6 +7,8 @@ if(EXISTS ${CROSS_ROOTFS}/bin/freebsd-version)
 elseif(EXISTS ${CROSS_ROOTFS}/usr/platform/i86pc)
   set(CMAKE_SYSTEM_NAME SunOS)
   set(ILLUMOS 1)
+elseif(EXISTS ${CROSS_ROOTFS}/boot/system/develop/headers/config/HaikuConfig.h)
+  set(CMAKE_SYSTEM_NAME Haiku)
 else()
   set(CMAKE_SYSTEM_NAME Linux)
   set(LINUX 1)
@@ -72,6 +74,9 @@ elseif (FREEBSD)
 elseif (ILLUMOS)
   set(CMAKE_SYSTEM_PROCESSOR "x86_64")
   set(TOOLCHAIN "x86_64-illumos")
+elseif (CMAKE_SYSTEM_NAME STREQUAL "Haiku")
+  set(CMAKE_SYSTEM_PROCESSOR "x86_64")
+  set(TOOLCHAIN "x86_64-unknown-haiku")
 else()
   message(FATAL_ERROR "Arch is ${TARGET_ARCH_NAME}. Only armel, arm, armv6, arm64, ppc64le, s390x and x86 are supported!")
 endif()
@@ -128,6 +133,41 @@ elseif(FREEBSD)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=lld")
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fuse-ld=lld")
     set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -fuse-ld=lld")
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Haiku")
+    set(CMAKE_SYSROOT "${CROSS_ROOTFS}")
+
+    set(TOOLSET_PREFIX ${TOOLCHAIN}-)
+    function(locate_toolchain_exec exec var)
+        string(TOUPPER ${exec} EXEC_UPPERCASE)
+        if(NOT "$ENV{CLR_${EXEC_UPPERCASE}}" STREQUAL "")
+            set(${var} "$ENV{CLR_${EXEC_UPPERCASE}}" PARENT_SCOPE)
+            return()
+        endif()
+
+        set(SEARCH_PATH "${CROSS_ROOTFS}/generated/cross-tools-x86_64/bin")
+
+        find_program(EXEC_LOCATION_${exec}
+            PATHS ${SEARCH_PATH}
+            NAMES
+            "${TOOLSET_PREFIX}${exec}${CLR_CMAKE_COMPILER_FILE_NAME_VERSION}"
+            "${TOOLSET_PREFIX}${exec}")
+
+        if (EXEC_LOCATION_${exec} STREQUAL "EXEC_LOCATION_${exec}-NOTFOUND")
+            message(FATAL_ERROR "Unable to find toolchain executable. Name: ${exec}, Prefix: ${TOOLSET_PREFIX}.")
+        endif()
+        set(${var} ${EXEC_LOCATION_${exec}} PARENT_SCOPE)
+    endfunction()
+
+    set(CMAKE_SYSTEM_PREFIX_PATH "${CROSS_ROOTFS}")
+
+    locate_toolchain_exec(gcc CMAKE_C_COMPILER)
+    locate_toolchain_exec(g++ CMAKE_CXX_COMPILER)
+
+    set(CMAKE_C_STANDARD_LIBRARIES "${CMAKE_C_STANDARD_LIBRARIES} -lssp")
+    set(CMAKE_CXX_STANDARD_LIBRARIES "${CMAKE_CXX_STANDARD_LIBRARIES} -lssp")
+
+    # let CMake set up the correct search paths
+    include(Platform/Haiku)
 elseif(ILLUMOS)
     set(CMAKE_SYSROOT "${CROSS_ROOTFS}")
 
@@ -214,11 +254,14 @@ elseif(TARGET_ARCH_NAME STREQUAL "x86")
 elseif(ILLUMOS)
   add_toolchain_linker_flag("-L${CROSS_ROOTFS}/lib/amd64")
   add_toolchain_linker_flag("-L${CROSS_ROOTFS}/usr/amd64/lib")
+elseif(HAIKU)
+  add_toolchain_linker_flag("-lgcc_s")
+  add_toolchain_linker_flag("-lnetwork")
 endif()
 
 # Specify compile options
 
-if((TARGET_ARCH_NAME MATCHES "^(arm|armv6|armel|arm64|ppc64le|s390x)$" AND NOT ANDROID) OR ILLUMOS)
+if((TARGET_ARCH_NAME MATCHES "^(arm|armv6|armel|arm64|ppc64le|s390x)$" AND NOT ANDROID) OR ILLUMOS OR HAIKU)
   set(CMAKE_C_COMPILER_TARGET ${TOOLCHAIN})
   set(CMAKE_CXX_COMPILER_TARGET ${TOOLCHAIN})
   set(CMAKE_ASM_COMPILER_TARGET ${TOOLCHAIN})
@@ -250,6 +293,12 @@ if(TIZEN)
     add_compile_options(-Wno-deprecated-declarations) # compile-time option
     add_compile_options(-D__extern_always_inline=inline) # compile-time option
   endif()
+endif()
+
+if(HAIKU)
+  add_compile_options(-fPIC)
+  add_definitions(-D_GNU_SOURCE)
+  add_definitions(-D_BSD_SOURCE)
 endif()
 
 # Set LLDB include and library paths for builds that need lldb.


### PR DESCRIPTION
### To double check:

* [x] The right tests are in and and the right validation has happened.  Guidance:  https://github.com/dotnet/arcade/tree/main/Documentation/Validation

(I hope so?)

These are the changes that should be merged to dotnet/arcade.

Because many of these is your work and you mentioned that you want to upstream this yourself, I'm opening a pull request here (instead of directly in dotnet).

With [krb5](http://github.com/haikuports/haikuports/pull/7009/) already on [HaikuDepot](https://depot.haiku-os.org/#!/pkg/krb5/haikuports/haikuports_x86_64/1/20/-/-/1/x86_64?bcguid=bc173-XONW)  `build-rootfs.sh` should work properly.
